### PR TITLE
#166185725 Add slack integration for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,8 @@ script:
 
   # Code coverage
   - coverage report
+
+  # slack integration for Travis builds
+notifications:
+  slack:
+    secure: "oZN3QSdXSCFYw0Ij4tHTWZ/YSZ+YeMkNAUuUWASZAo0ut72hhk716bpt2QUqFMzHatQSJP+VK3UBLCnFueuAVeurjR3fBqNLaB0/745tqqSglI7fkz4flroDxlzn8b1nmIwaIWTKq7Qkihb0Qy9Y7u+iCpwddZha1drPQPNi0LxNDUnia4jXBjlH5zwCSYsAWUW08WeGs56AYQeCSFsnYL3on3YYuDtAMByMyrKwT5k8Duq/4j5+4oat5EUak+iF6KXefbF3YhSEdYX9+mWA5Mt9puPCylI0tRPfwp3vQdpHZj4uJIonc/WoNuOmSXZ41Va9gxpeegvcCEG+DVmq7XVbJy7I7OD7rcFQ4xS/7GSWdE/udLh3TLr7XlXdlnWIDaJI7qnYwJyZAXuKsTfJTdc5FDSuJy9Kz12wOgqqf8O6dpRuDKjdzyBMaCYL+ZJehIn2/pqS7teMFxwS5xG4NmkJTxDy0aHkllbLvxpWKxx0CrH7d1e0vABNtFYfI+P8eNvggMx3gbuPn9YKTMZp9ssYa+6ejh+BoSwgyJ1zlsPrLBh5oSone9YAmun0yiWbMxE775wehb0T9kogRJ+X0ueRj9IpYoqKSgBTIDD1LAH1AZtHxE5kyeqW+IKUw4mQvvtPeqx/z5wJJuYHiP1+ENsCh2OH3rag1ytZy/4ec6Y="


### PR DESCRIPTION
#### What does this PR do?
Add slack integration for Continuous Integrations
#### Description of Task to be completed?

- [x] Add Github configurations to slack.

- [x] Add Pivotal Tracker configurations to slack.

- [x] Add Travis CI configurations to slack.

- [x] Add notification settings to `.travis.yml` file

#### Any background context you want to provide?
- Travis CI is a continuous integration platform that takes care of running your software tests and deploying your apps.
- This integration will allow our team to receive notifications in Slack.

#### What are the relevant pivotal tracker stories?
[#166185725](https://www.pivotaltracker.com/story/show/166185725)

#### Screenshots 
Team slack channel having Github, Pivotal Tracker and TRAVIS CI integrations running.
<img width="781" alt="Screenshot 2019-05-28 at 10 56 08" src="https://user-images.githubusercontent.com/9926422/58460953-4dcd5f00-8137-11e9-8759-0780f006449d.png">
