### PR TITLE
#166185726 Decide how to present deactivated users in gym overview.

### DIFF
--- a/wger/core/static/css/present_deactivated_users.css
+++ b/wger/core/static/css/present_deactivated_users.css
@@ -1,0 +1,39 @@
+/* Style the tab */
+.tab {
+    overflow: hidden;
+    border: 1px solid #ccc;
+    background-color: #4b62a0;
+  }
+  
+  /* Style the buttons that are used to open the tab content */
+.tab button {
+    background-color: inherit;
+    float: left;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    padding: 14px 16px;
+    transition: 0.3s;
+  }
+  
+  /* Change background color of buttons on hover */
+.tab button:hover {
+    background-color: #ddd;
+  }
+  
+  /* Create an active/current tablink class */
+.tab button.active {
+    background-color: #ccc;
+  }
+  
+  /* Style the tab content */
+.tabcontent {
+    display: none;
+    padding: 6px 12px;
+    border: 1px solid #ccc;
+    border-top: none;
+  }
+
+#deactivated_users{
+    background-color: rgb(245, 246, 253);
+}

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -508,11 +508,15 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
         Return a list with the users, not really a queryset.
         '''
         out = {'admins': [],
-               'members': []}
+               'active_members': [],
+               'deactivated_members': []}
+        specific_users = User.objects.select_related('usercache', 'userprofile__gym').all()
 
-        for u in User.objects.select_related('usercache', 'userprofile__gym').all():
-            out['members'].append({'obj': u,
-                                   'last_log': u.usercache.last_activity})
+        for u in specific_users:
+            if u.is_active:
+                out['active_members'].append({'obj': u, 'last_log': u.usercache.last_activity})
+            else:
+                out['deactivated_members'].append({'obj': u, 'last_log': u.usercache.last_activity})
 
         return out
 
@@ -527,5 +531,6 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
                                           _('Name'),
                                           _('Last activity'),
                                           _('Gym')],
-                                 'users': context['object_list']['members']}
+                                 'active_users': context['object_list']['active_members'],
+                                 'deactivated_users': context['object_list']['deactivated_members']}
         return context

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -1,6 +1,7 @@
 {% load i18n staticfiles %}
 
 <link rel="stylesheet" type="text/css" href="{% static 'bower_components/datatables/media/css/dataTables.bootstrap.min.css' %}">
+<link rel="stylesheet" type="text/css" href="{% static 'css/present_deactivated_users.css' %}">
 <script src="{% static 'bower_components/datatables/media/js/jquery.dataTables.min.js' %}" ></script>
 <script src="{% static 'bower_components/datatables/media/js/dataTables.bootstrap.min.js' %}" ></script>
 <script>
@@ -14,6 +15,16 @@ $(document).ready( function () {
 });
 </script>
 
+<div class="tab">
+    <button class="tablinks" onclick="displayMembers(event, 'active_users')" id="defaultOpen">Active Users</button>
+    <button class="tablinks" onclick="displayMembers(event, 'deactivated_users')">Deactivated Users</button>
+</div>
+
+<!-- table for active members -->
+
+ <div id="active_users" class="tabcontent">
+<table class="table table-hover" class="main_member_list">
+
 <table class="table table-hover" id="main_member_list">
 <thead>
 <tr>
@@ -23,7 +34,7 @@ $(document).ready( function () {
 </tr>
 </thead>
 <tbody>
-{% for current_user in user_table.users %}
+{% for current_user in user_table.active_users %}
 <tr>
     <td>
         {{current_user.obj.pk}}
@@ -52,3 +63,69 @@ $(document).ready( function () {
 {% endfor %}
 </tbody>
 </table>
+
+</div>
+
+<!-- table for deactivated members -->
+
+ <div id="deactivated_users" class="tabcontent">
+<table class="table table-hover" class="main_member_list">
+    <thead>
+    <tr>
+        {% for key in user_table.keys %}
+            <th>{{ key }}</th>
+        {% endfor %}
+    </tr>
+    </thead>
+    <tbody>
+    {% for current_user in user_table.deactivated_users %}
+    <tr>
+        <td>
+            {{current_user.obj.pk}}
+        </td>
+        <td>
+            <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+        </td>
+        <td>
+            {{current_user.obj.get_full_name}}
+        </td>
+        <td data-order="{{current_user.last_log|date:'U'}}">
+            {{current_user.last_log|default:'-/-'}}
+        </td>
+        {% if show_gym %}
+        <td>
+            {% if current_user.obj.userprofile.gym_id %}
+                <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                {{ current_user.obj.userprofile.gym }}
+                </a>
+            {% else %}
+                -/-
+            {% endif %}
+        </td>
+        {% endif %}
+    </tr>
+    {% endfor %}
+    </tbody>
+    </table>
+</div>
+
+<script>
+function displayMembers(evt, memberTab) {
+  var i;
+  var tabcontent;
+  var tablinks;
+  tabcontent = document.getElementsByClassName('tabcontent');
+    for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = 'none';
+}
+  tablinks = document.getElementsByClassName('tablinks');
+    for (i = 0;
+    i < tablinks.length;
+    i++) {
+      tablinks[i].className = tablinks[i].className.replace(' active', '');
+}
+  document.getElementById(memberTab).style.display = 'block';
+  evt.currentTarget.className += ' active';
+}
+document.getElementById('defaultOpen').click();
+</script>


### PR DESCRIPTION
#### What does this PR do?
Decide how to present deactivated users in gym overview.

#### Description of Task to be completed?

- [x] Filter active  users

- [x] Filter deactivated users

- [x] Modify the `partial_user_list` template to show only active users in the default list.

- [x] Add another page to the same template that shows inactive users

#### How should this be manually tested?
Follow documented steps to set up the project locally on your machine.
- Run server using command `python manage.py runserver`
- Navigate to the user list URL [http://127.0.0.1:8000/en/user/list ](http://127.0.0.1:8000/en/user/list)

#### Any background context you want to provide?
At the moment, the only way to determine whether a gym member is active or not is to open his detail view. A better alternative would be to list only active members in the default list and have a second overview page for the deactivated ones.

#### What are the relevant pivotal tracker stories?
[#166185726](https://www.pivotaltracker.com/story/show/166185726)

#### Screenshots:
1. Default page showing `active users`.
<img width="1411" alt="Screenshot 2019-06-06 at 14 35 49" src="https://user-images.githubusercontent.com/9926422/59030056-8cb29180-8868-11e9-8498-0162ebafcdea.png">


2. Second view showing `Deactivated users`.
<img width="1411" alt="Screenshot 2019-06-06 at 14 36 07" src="https://user-images.githubusercontent.com/9926422/59030080-9c31da80-8868-11e9-82da-ca5770588404.png">



