### PR TITLE
#166185728 Show all infos for an exercise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ install:
 
 # Create test databases
 before_script:
-  - npm install --global gulp-cli
+  - npm install --global -gulp-cli
+  - npm install
   - if [[ "$DB" = "postgresq" ]]; then psql -c 'DROP DATABASE IF EXISTS test_wger;' -U postgres; fi
   - if [[ "$DB" = "postgresql" ]]; then psql -c 'CREATE DATABASE test_wger;' -U postgres; fi
 

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -25,6 +25,24 @@ from wger.exercises.models import (
 )
 
 
+class ListAllSerializer(serializers.ModelSerializer):
+    '''
+    Special Exercise List serializer
+    '''
+    my_url = serializers.SerializerMethodField('get_absolute_url')
+
+    @classmethod
+    def get_absolute_url(cls, obj):
+        '''
+        Returns the canonical URL to view an exercise
+        '''
+        return "/api/v2/exercise/special/{}".format(obj.id)
+
+    class Meta:
+        model = Exercise
+        fields = ('name', 'my_url')
+
+
 class ExerciseSerializer(serializers.ModelSerializer):
     '''
     Exercise serializer

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -19,11 +19,12 @@ from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route, api_view
-
+from rest_framework.views import APIView
 from easy_thumbnails.alias import aliases
 from easy_thumbnails.files import get_thumbnailer
 
 from django.utils.translation import ugettext as _
+from django.http import Http404
 
 from wger.config.models import LanguageConfig
 from wger.exercises.api.serializers import (
@@ -34,6 +35,7 @@ from wger.exercises.api.serializers import (
     EquipmentSerializer,
     ExerciseCommentSerializer
 )
+from wger.exercises.api.serializers import ListAllSerializer
 from wger.exercises.models import (
     Exercise,
     Equipment,
@@ -44,6 +46,29 @@ from wger.exercises.models import (
 )
 from wger.utils.language import load_item_languages, load_language
 from wger.utils.permissions import CreateOnlyPermission
+
+
+class ExercisesListSpecial(APIView):
+    @classmethod
+    def get(cls, request):
+        queryset = Exercise.objects.all()
+        serializer = ListAllSerializer(data=queryset, many=True)
+        serializer.is_valid()
+        return Response(serializer.data)
+
+
+class ExerciseSpecial(APIView):
+    @classmethod
+    def get_object(cls, pk):
+        try:
+            return Exercise.objects.get(pk=pk)
+        except Exercise.DoesNotExist:
+            raise Http404
+
+    def get(self, request, pk):
+        snippet = self.get_object(pk)
+        serializer = ExerciseSerializer(snippet)
+        return Response(serializer.data)
 
 
 class ExerciseViewSet(viewsets.ModelViewSet):

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -17,6 +17,7 @@ import json
 from django.core import mail
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
+from rest_framework import status
 
 from wger.core.tests.base_testcase import (
     STATUS_CODES_FAIL,
@@ -390,6 +391,19 @@ class ExercisesTestCase(WorkoutManagerTestCase):
 
         self.user_login('test')
         self.search_exercise()
+
+    def test_show_all_excercise_infos(self):
+        response = self.client.get('/api/v2/exercise/special/')
+        self.assertIsInstance(response.data, list)
+        self.assertTrue(len(response.data), len(Exercise.objects.all()))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_show_single_excercise_info(self):
+        self.user_login('admin')
+        self.add_exercise_success(admin=True)
+        response = self.client.get('/api/v2/exercise/special/1', follow=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], 'An exercise')
 
 
 class DeleteExercisesTestCase(WorkoutManagerDeleteTestCase):

--- a/wger/exercises/urls.py
+++ b/wger/exercises/urls.py
@@ -28,7 +28,6 @@ from wger.exercises.views import (
 )
 
 
-
 # sub patterns for muscles
 patterns_muscle = [
     url(r'^overview/$',
@@ -116,7 +115,6 @@ patterns_equipment = [
 ]
 
 
-# sub patterns for exercises
 patterns_exercise = [
     url(r'^overview/$',
         exercises.ExerciseListView.as_view(),
@@ -152,10 +150,10 @@ patterns_exercise = [
 
 
 urlpatterns = [
-   url(r'^muscle/', include(patterns_muscle, namespace="muscle")),
-   url(r'^image/', include(patterns_images, namespace="image")),
-   url(r'^comment/', include(patterns_comment, namespace="comment")),
-   url(r'^category/', include(patterns_category, namespace="category")),
-   url(r'^equipment/', include(patterns_equipment, namespace="equipment")),
-   url(r'^', include(patterns_exercise, namespace="exercise")),
+    url(r'^muscle/', include(patterns_muscle, namespace="muscle")),
+    url(r'^image/', include(patterns_images, namespace="image")),
+    url(r'^comment/', include(patterns_comment, namespace="comment")),
+    url(r'^category/', include(patterns_category, namespace="category")),
+    url(r'^equipment/', include(patterns_equipment, namespace="equipment")),
+    url(r'^', include(patterns_exercise, namespace="exercise")),
 ]

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -60,7 +60,6 @@ from wger.utils.widgets import (
 from wger.config.models import LanguageConfig
 from wger.weight.helpers import process_log_entries
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -30,6 +30,9 @@ from wger.exercises.sitemap import ExercisesSitemap
 from wger.utils.generic_views import TextTemplateView
 from wger.utils.generic_views import WebappManifestView
 
+from wger.exercises.api.views import ExercisesListSpecial
+from wger.exercises.api.views import ExerciseSpecial
+
 from wger.exercises.api import resources as exercises_api
 from wger.nutrition.api import resources as nutrition_api
 from wger.manager.api import resources as manager_api
@@ -166,6 +169,17 @@ urlpatterns += [
     url(r'^api/v2/exercise/search/$',
         exercises_api_views.search,
         name='exercise-search'),
+
+    url(r'^api/v2/exercise/special/$',
+        ExercisesListSpecial.as_view(),
+        name='exercise-special'),
+
+     url(r'^api/v2/exercise/special/(?P<pk>\d+)/$',
+        ExerciseSpecial.as_view(),
+        name='exercise-special-detail'),
+
+
+
     url(r'^api/v2/ingredient/search/$',
         nutrition_api_views.search,
         name='ingredient-search'),


### PR DESCRIPTION
#### What does this PR do?
Have exercises details on a single endpoint

#### Description of Task to be completed?
There should be a new read-only API endpoint that collects all the information of an exercise such as muscles, category, images, etc. This makes it easier for clients to get all the info since only a single request is needed to be done.

### How should this be manually tested?
- Start the server, using the command: python manage.py runserver.
- Open up your preferred REST client, such as Postman, and call the endpoint /api/v2/exercise/special/ as below.

Request
GET http://127.0.0.1:8000/api/v2/exercise/special/
Response
```
[
    {
        "name": "2 Handed Kettlebell swing",
        "my_url": "/api/v2/exercise/special/345"
    },
    {
        "name": "Aalex Gambe alte al muro",
        "my_url": "/api/v2/exercise/special/350"
    },
    {
        "name": "Abduktoren-Maschine",
        "my_url": "/api/v2/exercise/special/174"
    }
]
```
From there, a user selects an exercise whose details they want to see. And this is what they get, using a read-only endpoint /api/v2/exercise/special/{id}

Request
GET http://127.0.0.1:8000/api/v2/exercise/special/345
```
{
    "id": 345,
    "license_author": "deusinvictus",
    "status": "2",
    "description": "<p>Two Handed Russian Style Kettlebell swing</p>",
    "name": "2 Handed Kettlebell swing",
    "name_original": "",
    "creation_date": "2015-08-03",
    "uuid": "c788d643-150a-4ac7-97ef-84643c6419bf",
    "license": 2,
    "category": 10,
    "language": 2,
    "muscles": [],
    "muscles_secondary": [],
    "equipment": [
        10
    ]
}
```

#### What are the relevant pivotal tracker stories?
[#166185728](https://www.pivotaltracker.com/story/show/166185728)