### PR TITLE
#166185727 Cache nutritional values for plan

### DIFF
--- a/wger/nutrition/__init__.py
+++ b/wger/nutrition/__init__.py
@@ -17,5 +17,17 @@
 
 
 from wger import get_version
+from django.apps import AppConfig
 
 VERSION = get_version()
+
+
+class NutritionConfig(AppConfig):
+    name = "wger.nutrition"
+
+    def ready(self):
+        import wger.nutrition.signals
+        return wger.nutrition.signals
+
+
+default_app_config = 'wger.nutrition.NutritionConfig'

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,26 @@
+from django.core.cache import cache
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from wger.utils.cache import cache_mapper
+
+signals = [post_save, post_delete]
+
+
+@receiver(signals, sender=NutritionPlan)
+@receiver(signals, sender=Meal)
+@receiver(signals, sender=MealItem)
+def cache_deletion_on_change(sender, instance, **kwargs):
+    '''
+    Delete cache data for a particular nutrion plan once an add, edit
+    or delete occurs on Meal, MealItem classes and the NutritionPlan class.
+    '''
+    if sender == Meal:
+        nutrition_plan_id = instance.plan_id
+    elif sender == MealItem:
+        nutrition_plan_id = Meal.objects.get(id=instance.meal_id).plan_id
+    else:
+        nutrition_plan_id = instance.id
+
+    cache.delete(
+        cache_mapper.get_nutritional_value_plan(nutrition_plan_id))

--- a/wger/nutrition/tests/test_cache_nutrional.py
+++ b/wger/nutrition/tests/test_cache_nutrional.py
@@ -1,0 +1,86 @@
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from wger.core.models import Language
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from wger.utils.cache import cache_mapper
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+
+
+class CacheNutritionalPlanTestCase(WorkoutManagerTestCase):
+
+    @classmethod
+    def create_nutrition_data(self):
+        nutrition_plan = NutritionPlan()
+        nutrition_plan.user = User.objects.create_user(username='reifred')
+        nutrition_plan.language = Language.objects.get(short_name="en")
+        nutrition_plan.save()
+
+        meal = Meal()
+        meal.plan = nutrition_plan
+        meal.order = 1
+        meal.save()
+
+        meal_item = MealItem()
+        meal_item.meal = meal
+        meal_item.amount = 1
+        meal_item.ingredient_id = 1
+        meal_item.order = 1
+
+        return [nutrition_plan, meal, meal_item]
+
+    def test_presence_of_cache_data_without_setting_nutritional_plan_in_cache(self):
+        nutritional_plan = self.create_nutrition_data()[0]
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+
+    def test_presence_of_cache_data_after_setting_nutritional_plan_in_cache(self):
+        nutritional_plan = self.create_nutrition_data()[0]
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(
+            cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+
+    def test_cache_key_deletion_on_save_of_a_nutritional_plan(self):
+        nutritional_plan = self.create_nutrition_data()[0]
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+        nutritional_plan.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+
+    def test_cache_key_deletion_on_delete_of_a_nutritional_plan(self):
+        nutritional_plan = self.create_nutrition_data()[0]
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+        nutritional_plan.delete()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+
+    def test_cache_key_deletion_on_save_of_a_meal(self):
+        nutrition_data = self.create_nutrition_data()
+        nutritional_plan = nutrition_data[0]
+        meal = nutrition_data[1]
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+        meal.save()
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+
+    def test_cache_key_deletion_on_delete_of_a_meal(self):
+        nutrition_data = self.create_nutrition_data()
+        nutritional_plan = nutrition_data[0]
+        meal = nutrition_data[1]
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+        meal.delete()
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+
+    def test_cache_key_deletion_on_save_of_a_meal_item(self):
+        nutrition_data = self.create_nutrition_data()
+        nutritional_plan = nutrition_data[0]
+        meal_item = nutrition_data[2]
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))
+        meal_item.save()
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutritional_value_plan(nutritional_plan)))

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -67,6 +67,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITIONAL_PLAN_REPRESENTATION = 'nutritional-plan-representation-{0}'
 
     def get_pk(self, param):
         '''
@@ -108,6 +109,12 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_CANONICAL_REPRESENTATION.format(self.get_pk(param))
+
+    def get_nutritional_value_plan(self, param):
+        '''
+        Return the nutritional value plan representation
+        '''
+        return self.NUTRITIONAL_PLAN_REPRESENTATION.format(self.get_pk(param))
 
     def get_workout_log_list(self, hash_value):
         '''


### PR DESCRIPTION
#### What does this PR do?
- cache the nutritional_info dictionary in NutritionPlans
- add signals that delete the cache key every time a NutritionPlan, Meal, and MealItem is added, edited or deleted.
#### Description of Task to be completed?
If a user has many plans (approx. more than 25), the overview renders slowly as too many DB-queries are fired just to calculate the total calories. Some caching of the values is probably the easiest solution, similar to the canonical_representation for workouts.

### How should this be manually tested?
Switch to this branch and run tests for this feature using
 `python manage.py test wger.nutrition.tests.test_cache_nutrional`

#### What are the relevant pivotal tracker stories?
[#166185727](https://www.pivotaltracker.com/story/show/166185727)
