### PR TITLE
#166185745 Enable social logins with Google and Facebook

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: gunicorn wger.wsgi --log-file -
+release: python manage.py migrate

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,8 @@ gunicorn==19.9.0
 psycopg2==2.7.7
 psycopg2-binary==2.7.7
 npm
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 # REST API
 djangorestframework>=3.2,<3.3
 django-filter==1.1.0

--- a/wger/core/templates/base.html
+++ b/wger/core/templates/base.html
@@ -16,8 +16,6 @@ browsing the site as the user "{{current_user}}", all actions are performed on h
 </div>
 {% endif %}
 
-
-
 <div class="row">
     <div class="col-sm-8">
         <h2 id="page-title" class="page-header">
@@ -43,8 +41,6 @@ browsing the site as the user "{{current_user}}", all actions are performed on h
     </div>
 </div>
 
-
-
 <div class="row">
     <div class="col-sm-8" id="main-content">
         {% if messages and not no_messages %}
@@ -61,10 +57,28 @@ browsing the site as the user "{{current_user}}", all actions are performed on h
         <div id="content">
         {% block content %}{% endblock %}
         </div>
+
+        <p><strong>-- OR --</strong></p>
+        
+        <div class="col-sm-6 form-group">
+                <a href="{% url 'social:begin' 'twitter' %}" class="btn btn-block btn-social btn-twitter" role="button">
+                    <i class="fa fa-twitter fa-fw"></i>
+                    Login with Twitter
+                </a>
+        
+                <a href="{% url 'social:begin' 'facebook' %}" class="btn btn-block btn-social btn-facebook" role="button">
+                    <i class="fa fa-facebook fa-fw"></i>
+                    Login with Facebook
+                </a>
+                <a href="{% url 'social:begin' 'google-oauth2' %}" class="btn btn-block btn-social btn-google" role="button">
+                    <i class="fa fa-google fa-fw"></i>
+                    Login with Google
+                </a>
+                      </div>    
     </div>
     <div class="col-sm-4" id="main-sidebar">
         {% block sidebar %}
         {% endblock %}
-    </div>
+    </div>          
 </div>
 {% endblock %}

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -56,6 +56,8 @@
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/shariff/1.26.2/shariff.min.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/metrics-graphics/2.15.6/metricsgraphics.css">
     <link rel="stylesheet" type="text/css" href="{% static 'css/metricsgraphics-custom.css' %}">
+    <link rel="stylesheet" type="text/css" href="https://lipis.github.io/bootstrap-social/bootstrap-social.css">
+
     {% endcompress %}
 
     <link rel="icon" href="{% static 'images/favicon.png' %}" type="image/png">

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -86,17 +86,20 @@ INSTALLED_APPS = (
 
     # django-bower for installing bower packages
     'djangobower',
+
+    # social-login django
+    'social_django',
 )
 
 # added list of external libraries to be installed by bower
 BOWER_INSTALLED_APPS = (
     'jquery#2.1.x',
-    'bootstrap',
+    'bootstrap#3.3.x',
     'd3',
-    'shariff',
+    'shariff#1.24.1',
     'tinymce-dist',
     'DataTables',
-    'components-font-awesome',
+    'components-font-awesome#4.7.x',
     'tinymce',
     'metrics-graphics',
     'devbridge-autocomplete#1.2.x',
@@ -127,11 +130,18 @@ MIDDLEWARE_CLASSES = (
     # Django mobile
     'django_mobile.middleware.MobileDetectionMiddleware',
     'django_mobile.middleware.SetFlavourMiddleware',
+
+    # social login
+    'social_django.middleware.SocialAuthExceptionMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
-    'wger.utils.helpers.EmailAuthBackend'
+    'wger.utils.helpers.EmailAuthBackend',
+    # social login
+    'social_core.backends.twitter.TwitterOAuth',
+    'social_core.backends.facebook.FacebookOAuth2',
+    'social_core.backends.google.GoogleOAuth2',
 )
 
 TEMPLATES = [
@@ -150,6 +160,10 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
+
+                # social login
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
 
                 # Django mobile
                 'django_mobile.context_processors.flavour',
@@ -195,7 +209,7 @@ EMAIL_SUBJECT_PREFIX = '[wger] '
 #
 LOGIN_URL = '/user/login'
 LOGIN_REDIRECT_URL = '/'
-
+SOCIAL_AUTH_RAISE_EXCEPTIONS = False
 
 #
 # Internationalization
@@ -272,6 +286,8 @@ LOGGING = {
 #
 RECAPTCHA_USE_SSL = True
 
+# social auth namespce
+SOCIAL_AUTH_URL_NAMESPACE = 'social'
 
 #
 # Cache
@@ -370,3 +386,16 @@ WGER_SETTINGS = {
     'EMAIL_FROM': 'wger Workout Manager <wger@example.com>',
     'TWITTER': False
 }
+
+# social login
+SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get('SOCIAL_AUTH_FACEBOOK_KEY')
+SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get('SOCIAL_AUTH_FACEBOOK_SECRET')
+
+# twitter
+SOCIAL_AUTH_TWITTER_KEY = os.environ.get('SOCIAL_AUTH_TWITTER_KEY')
+SOCIAL_AUTH_TWITTER_SECRET = os.environ.get('SOCIAL_AUTH_TWITTER_SECRET')
+SOCIAL_AUTH_LOGIN_URL = '/'
+
+# google
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET')

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -124,6 +124,7 @@ router.register(r'weightentry', weight_api_views.WeightEntryViewSet, base_name='
 from django.contrib import admin
 admin.autodiscover()
 
+
 #
 # Sitemaps
 #
@@ -147,8 +148,8 @@ urlpatterns = i18n_patterns(
     url(r'^sitemap\.xml$',
         sitemap,
         {'sitemaps': sitemaps},
-        name='sitemap')
-)
+        name='sitemap'),
+          )
 
 #
 # URLs without language prefix
@@ -169,6 +170,10 @@ urlpatterns += [
         nutrition_api_views.search,
         name='ingredient-search'),
     url(r'^api/v2/', include(router.urls)),
+
+  # social_login url
+    url(r'^oauth/', include('social_django.urls', namespace='social')),
+
 ]
 
 #


### PR DESCRIPTION
#### What does this PR do?
Currently, a new user cannot log in with their pre-existing social media account.

This makes it happen!

#### Description of Task to be completed?

- [x] Configure google social logins

- [x] Configure Facebook login

- [x] Configure Twitter login

#### How should this be manually tested?
- Install the required tools using `pip install` in addition to what you have installed.

       social-auth-app-django==3.1.0
       social-auth-core==3.2.0 
- Run `python manage.py migrate` to add the migrations that come with `social-auth-app-django`
- For this functionality to work, you have to use a hosted version of the application
- Navigate to login interface [login page](https://wger-kronos.herokuapp.com/en/user/login)
- From which you will have a variety of login options to choose from.

#### What are the relevant pivotal tracker stories?
[#166185745](https://www.pivotaltracker.com/story/show/166185745)

#### Screenshots (if appropriate)
1. login page
<img width="1353" alt="Screenshot 2019-06-07 at 13 51 23" src="https://user-images.githubusercontent.com/9926422/59099630-4c1c4c00-892c-11e9-9887-d886a3932bdc.png">


2. Google login interface
<img width="1207" alt="Screenshot 2019-06-06 at 15 49 49" src="https://user-images.githubusercontent.com/9926422/59034389-9e4d6680-8873-11e9-8286-3af46d3bbc31.png">

3. Facebook login interface.
<img width="1207" alt="Screenshot 2019-06-06 at 16 10 33" src="https://user-images.githubusercontent.com/9926422/59035438-f6856800-8875-11e9-8f6b-8e788af8afc7.png">

4. Twitter login interface
<img width="1207" alt="Screenshot 2019-06-06 at 18 13 36" src="https://user-images.githubusercontent.com/9926422/59044946-c777f200-8887-11e9-91d7-24d924c1d131.png">
