### PR TITLE
#166185733 Make translations of exercises and ingredients easier

### DIFF
--- a/wger/exercises/tests/test_corrected_exercise.py
+++ b/wger/exercises/tests/test_corrected_exercise.py
@@ -34,6 +34,7 @@ class ExercisesCorrectionTestCase(WorkoutManagerTestCase):
                                      'name_original': 'my test exercise',
                                      'license': 2,
                                      'description': description,
+                                     'language': 1,
                                      'muscles': [3]})
 
         if fail:

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -271,6 +271,7 @@ class ExercisesTestCase(WorkoutManagerTestCase):
                                     {'category': 2,
                                      'name_original': 'my test exercise',
                                      'license': 1,
+                                     'language': 1,
                                      'description': description,
                                      'muscles': [1, 2]})
         count_after = Exercise.objects.count()

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -187,7 +187,8 @@ class ExercisesEditAddView(WgerFormMixin):
                           'muscles_secondary',
                           'equipment',
                           'license',
-                          'license_author']
+                          'license_author',
+                          'language']
 
             class Media:
                 js = ('/static/bower_components/tinymce/tinymce.min.js',)
@@ -223,7 +224,7 @@ class ExerciseAddView(ExercisesEditAddView, LoginRequiredMixin, CreateView):
         '''
         Set language, author and status
         '''
-        form.instance.language = load_language()
+        form.instance.language = load_language(form.instance.language.short_name)
         form.instance.set_author(self.request)
         return super(ExerciseAddView, self).form_valid(form)
 

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -248,8 +248,7 @@ class Ingredient(AbstractLicenseModel, models.Model):
         ordering = ["name", ]
 
     language = models.ForeignKey(Language,
-                                 verbose_name=_('Language'),
-                                 editable=False)
+                                 verbose_name=_('Language'))
 
     user = models.ForeignKey(User,
                              verbose_name=_('User'),

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -73,6 +73,7 @@ class EditIngredientTestCase(WorkoutManagerEditTestCase):
             'protein': 20,
             'carbohydrates': 10,
             'license': 2,
+            'language': 1,
             'license_author': 'me!'}
 
     def post_test_hook(self):
@@ -102,6 +103,7 @@ class AddIngredientTestCase(WorkoutManagerAddTestCase):
             'protein': 20,
             'carbohydrates': 10,
             'license': 2,
+            'language': 1,
             'license_author': 'me!'}
 
     def post_test_hook(self):

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -143,7 +143,8 @@ class IngredientMixin(WgerFormMixin):
               'fibres',
               'sodium',
               'license',
-              'license_author']
+              'license_author',
+              'language']
 
 
 class IngredientEditView(IngredientMixin, LoginRequiredMixin, PermissionRequiredMixin, UpdateView):
@@ -188,7 +189,9 @@ class IngredientCreateView(IngredientMixin, CreateView):
                              message,
                              fail_silently=True)
 
-        form.instance.language = load_language()
+        form.instance.language = load_language(
+            load_language(form.instance.language.short_name)
+        )
         return super(IngredientCreateView, self).form_valid(form)
 
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
#### What does this PR do?
- Add a field for specifying the language of either an exercise or an ingredient
#### Description of Task to be completed?
There is already support for that, but it is probably a bit hidden:

Every ingredient and exercise has a field indicating the language, which is automatically set as the user's current language when adding them.
The current list is then filtered based on this.

The user should be able to select which languages to show. They should not be shown only their current language.

### How should this be manually tested?
- Navigate to [add ingredient](https://wger-kronos-pr-20.herokuapp.com/en/nutrition/ingredient/add/) or exercise using your account. You will notice there is an added field for choosing a language when adding.
- Then [verify](https://wger-kronos-pr-20.herokuapp.com/en/nutrition/ingredient/pending/) your exercises or ingredients using the admin account. 

### Any background context you need to provide.
When adding an ingredient note that total energy is not the approximate sum of the energy provided by protein, carbohydrates, and fat.
Sample values could be.
Energy 69kcal, Protein 1.5g, Carbohydrates 17.6g, Sugar content in carbohydrates 8.55g, Fat 0.1g, Saturated fat 0.014g, Others 5.3g, Fiber 5.3g, Sodium 0.02g.

#### What are the relevant pivotal tracker stories?
[#166185733](https://www.pivotaltracker.com/story/show/166185733)

### Screenshots if available.
Adding an exercise view.
![image](https://user-images.githubusercontent.com/22131999/59271364-573ce800-8c5c-11e9-9732-816298687367.png)
Adding a ingredient view.
![image](https://user-images.githubusercontent.com/22131999/59271380-60c65000-8c5c-11e9-9a27-12625aff88bf.png)
Choice of languages.
![image](https://user-images.githubusercontent.com/22131999/59271395-67ed5e00-8c5c-11e9-9ce0-5ff0e4f44bc3.png)