### PR TITLE
#166185732 Reset exercise cache on muscle delete

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn wger.wsgi --log-file -
-release: chmod +x startup;./startup
+

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -77,6 +77,26 @@ class Muscle(models.Model):
         '''
         return False
 
+    def delete(self, *args, **kwargs):
+        """
+        Reset all cached info on muscle delete
+        """
+        for language in Language.objects.all():
+            delete_template_fragment_cache("exercise-overview", language.id)
+            delete_template_fragment_cache(
+                "exercise-overview-mobile", language.id
+            )
+            delete_template_fragment_cache(
+                "muscle-overview", language.id
+            )
+            delete_template_fragment_cache(
+                "equipment-overview", language.id
+            )
+        muscle_exercises = Exercise.objects.filter(muscles=self).iterator()
+        for exercise in muscle_exercises:
+            cache.delete(cache_mapper.get_exercise_muscle_bg_key(exercise.id))
+        super(Muscle, self).delete(*args, **kwargs)
+
 
 @python_2_unicode_compatible
 class Equipment(models.Model):

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -42,10 +42,20 @@ class MuscleListView(ListView):
     '''
     Overview of all muscles and their exercises
     '''
+
     model = Muscle
-    queryset = Muscle.objects.all().order_by('-is_front', 'name'),
     context_object_name = 'muscle_list'
     template_name = 'muscles/overview.html'
+
+    def get_queryset(self):
+        '''
+        Fetch a new set of muscles after cache reset.
+        '''
+
+        queryset = Muscle.objects.all().order_by('-is_front', 'name')
+        if self.template_name == 'muscles/overview.html':
+            return queryset,
+        return queryset
 
     def get_context_data(self, **kwargs):
         '''
@@ -118,4 +128,5 @@ class MuscleDeleteView(WgerDeleteMixin, LoginRequiredMixin, PermissionRequiredMi
         context['title'] = _(u'Delete {0}?').format(self.object.name)
         context['form_action'] = reverse(
             'exercise:muscle:delete', kwargs={'pk': self.kwargs['pk']})
+
         return context


### PR DESCRIPTION
#### What does this PR do?
- Reset exercise cache when deleting muscles

#### Description of Task to be completed?

- [x] clear cache upon muscle delete

#### How should this be manually tested?
- Login as admin 
```
username: admin
password: admin
```
- Look through Exercises tab on dashboard Navigation
- This will display a dropdown of various options
- Go to [muscles](https://wger-kronos-pr-21.herokuapp.com/en/exercise/muscle/admin-overview/)
- Add a test muscle then navigate back to [muscles overview](https://wger-kronos-pr-21.herokuapp.com/en/exercise/muscle/overview/)
- You should be able to see the added muscles.
- Get back to muscles page and delete the test muscle you created.
- When you navigate back to muscles overview, the muscle should have been cleared as well.
- To confirm this further, click on exercises where the muscle belonged. It should be cleared as well.

#### Any background context you want to provide?
It seems that after deleting a muscle, it keeps appearing in descriptions etc. This is probably due to the cache not being correctly reset.

The cache should be reset after a muscle has been deleted

#### What are the relevant pivotal tracker stories?
[#166185732](https://www.pivotaltracker.com/story/show/166185732)

#### Screenshots:
Add a test muscle
<img width="1276" alt="Screenshot 2019-06-12 at 15 30 09" src="https://user-images.githubusercontent.com/9926422/59351830-f37ff100-8d27-11e9-8ceb-2e0df870bce9.png">

Check that it is reflected in exercise overview
<img width="1276" alt="Screenshot 2019-06-12 at 15 30 40" src="https://user-images.githubusercontent.com/9926422/59351888-16120a00-8d28-11e9-9cf5-24e080a02dc8.png">

Delete the test muscle
<img width="1276" alt="Screenshot 2019-06-12 at 15 31 12" src="https://user-images.githubusercontent.com/9926422/59351910-21fdcc00-8d28-11e9-9a87-c16448747fb1.png">

Check that it has been cleared from exercise overview as well.
<img width="1276" alt="Screenshot 2019-06-12 at 15 31 32" src="https://user-images.githubusercontent.com/9926422/59351983-40fc5e00-8d28-11e9-910e-c95445a2365d.png">
