### PR TITLE
#166787340 Fix show gym users 

### DIFF
--- a/wger/core/fixtures/test-user-data.json
+++ b/wger/core/fixtures/test-user-data.json
@@ -476,6 +476,24 @@
         }
     },
     {
+        "pk": 24, 
+        "model": "auth.user", 
+        "fields": {
+            "username": "inactive", 
+            "first_name": "rita", 
+            "last_name": "rita", 
+            "is_active": false, 
+            "is_superuser": false, 
+            "is_staff": true, 
+            "last_login": "2012-09-25T21:18:00.042Z", 
+            "groups": [],
+            "user_permissions": [], 
+            "password": "pbkdf2_sha256$10000$dAmN8USC9lXU$G/N0SFsSO17Kjkc/f9p8t9cy2INDyGMPCYrsmvjjd4s=", 
+            "email": "inactive@example.com", 
+            "date_joined": "2012-07-30T14:28:16.672Z"
+        }
+    }, 
+    {
         "pk": 1, 
         "model": "core.userprofile",
         "fields": {

--- a/wger/gym/tests/test_members_list.py
+++ b/wger/gym/tests/test_members_list.py
@@ -1,0 +1,18 @@
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from django.core.urlresolvers import reverse_lazy
+
+
+class GymListTest(WorkoutManagerTestCase):
+    '''
+    test gym member list
+    '''
+
+    def test_user_list_returned(self):
+        self.user_login()
+
+        members_url = reverse_lazy('gym:gym:user-list', kwargs={'pk': 1})
+        response = self.client.get(members_url)
+
+        self.assertEqual(response.context['active_user_count'], 9)
+        self.assertEqual(response.context['deactivated_user_count'], 1)
+        self.assertEqual(response.context['admin_count'], 7)


### PR DESCRIPTION
#### What does this PR do?
- Show the users that are subscribed to the gym

#### Description of Task to be completed?

- [x] Refactor `GymListView`

#### How should this be manually tested?
Log in as an admin, gym manager or trainer and navigate to [members](https://wger-kronos-pr-27.herokuapp.com/en/gym/2/members)
#### Any background context you want to provide?
- At the moment only gym administrators and trainers are displayed in a gym. We would like to see the users that are subscribed to the gym as well

#### What are the relevant pivotal tracker stories?
[#166787340](https://www.pivotaltracker.com/story/show/166787340)

#### Screenshots
Gym members page now showing regular users as well.
<img width="1440" alt="Screenshot 2019-06-19 at 14 45 54" src="https://user-images.githubusercontent.com/9926422/59763061-5978f500-92a1-11e9-9d02-57dfbc02edfd.png">
