### PR TITLE
#166185746 Enable getting exercises for a body part when the mouse hovers over the body part

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -28,6 +28,17 @@ $(document).ready(function() {
             window.location.href = '/exercise/' + suggestion.data.id + '/view/'
         }
     });
+
+    // View attributes of exercises on hover
+    $(".nav-tabs >li").hover(function(e) {
+        $(this).toggleClass('active')
+        e.target.setAttribute('aria-expanded',true)
+        var elmId = e.target.id;
+        var tabId = elmId.split("-");
+        if(tabId.length>1){
+            $('#tab-'+tabId[1]).toggleClass('active') 
+        }  
+    });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
#### What does this PR do?
  - [x] Enable getting exercises for a body part when the mouse hovers over the body part

#### Description of Task to be completed?
  - [x] When the user accesses the exercise overview page, enable getting exercises for a body part when the mouse hovers over the body part.

#### How should this be manually tested?
  - [x] Browser to `Exercises` at the menu bar of the page and click on exercises, then hover over the nav-bar indicating the body parts to view the various exercises.
<img width="1440" alt="Screenshot 2019-06-20 at 10 41 26" src="https://user-images.githubusercontent.com/50827537/59830800-0bb7c780-9349-11e9-9df8-b7e6a16457c9.png">

#### What are the relevant pivotal tracker stories?
[#166185746](https://www.pivotaltracker.com/n/projects/2350327/stories/166185746)